### PR TITLE
error when 'name' is part of 'fullname'

### DIFF
--- a/src/folderUtils.js
+++ b/src/folderUtils.js
@@ -123,7 +123,7 @@ const folderType = 'folder';
   const stats = getStats(graph, url);
   const fullName = url.replace(/\/$/, '');
   const name = fullName.replace(/.*\//, '');
-  const parent = fullName.replace(name, '');
+  const parent = fullName.substr(0, fullname.lastIndexOf("/"))+"/";
   return {
     type: folderType,
     name,


### PR DESCRIPTION
Do replace the first occurence of 'name' in 'fullname' and not the last one as  expected.
'https://xx.solid.community/public/tt'  returns 'hps://xx.solid.community/public/tt' in lieu of 'https://xx.solid.community/public/'

the same problems occurs in 'solid-ide'