### PR TITLE
Set SolidApi.fetch to throw and added new tests

### DIFF
--- a/changes.log
+++ b/changes.log
@@ -61,4 +61,8 @@ JZ 2019-06-09 22:00 PDT
   * the addresses can then be used to delete,copy,etc. the .acl and .meta files
     using normal methods
 
-
+OA 2019-06-11 03:00 PDT
+  * to be consistent fetch now throws if response.ok is set to false
+    I've updated methods in SolidFileClient to use get and handle thrown errors
+  * added some tests for SolidApi
+  * added tests for apiUtils 

--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -36,6 +36,7 @@ class SolidAPI {
    */
   fetch (url, options) {
     return this._fetch(url, options)
+      .then(this._assertResponseOk)
   }
 
   /**
@@ -49,7 +50,6 @@ class SolidAPI {
       method: 'GET',
       ...options,
     })
-      .then(this._assertResponseOk)
   }
 
   /**
@@ -63,7 +63,6 @@ class SolidAPI {
       method: 'DELETE',
       ...options,
     })
-      .then(this._assertResponseOk)
   }
 
   /**
@@ -77,7 +76,6 @@ class SolidAPI {
       method: 'POST',
       ...options,
     })
-      .then(this._assertResponseOk)
   }
 
   /**
@@ -91,7 +89,6 @@ class SolidAPI {
       method: 'PUT',
       ...options,
     })
-      .then(this._assertResponseOk)
   }
 
   /**
@@ -105,7 +102,6 @@ class SolidAPI {
       method: 'PATCH',
       ...options,
     })
-      .then(this._assertResponseOk)
   }
 
   /**
@@ -119,7 +115,6 @@ class SolidAPI {
       method: 'HEAD',
       ...options,
     })
-      .then(this._assertResponseOk)
   }
 
   /**
@@ -133,7 +128,6 @@ class SolidAPI {
       method: 'OPTIONS',
       ...options,
     })
-      .then(this._assertResponseOk)
   }
 
   /**

--- a/src/SolidFileClient.js
+++ b/src/SolidFileClient.js
@@ -119,11 +119,7 @@ async getLinks(url){
     async readFile(url,request){
       let self=this
       return new Promise((resolve,reject)=>{
-        this.fetch(url,request).then( (res) => {
-          if(!res.ok) {
-            if(self._responseInterface) resolve(res)  
-            else reject(res)
-          }
+        this.get(url,request).then( (res) => {
           let type = res.headers.get('content-type')
           if(type.match(/(image|audio|video)/)){
             res.buffer().then( blob => {
@@ -156,12 +152,15 @@ async getLinks(url){
             contentType = this.folderUtils.guessFileType(url)
         }
   
-        const response = await this.fetch(url)
-        if (!response.ok) {
-            throw new Error(`Fetch for ${url} failed with status code ${response.status}: ${response.statusText}`)
+        try {
+          const response = await this.get(url)
+          // TODO: Parse response
+          return response
         }
-        // TODO: Parse response
-        return response
+        catch (e) {
+          return this._isoErr(e)
+          // throw new Error(`Fetch for ${url} failed with status code ${response.status}: ${response.statusText}`)
+        }
     }
 
     _err (e) {

--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -32,7 +32,7 @@ const getParentUrl = url => {
  */
 const getItemName = url => {
     url = removeSlashesAtEnd(url)
-    return url.substr(url.lastIndexOf('/'))
+    return url.substr(url.lastIndexOf('/') + 1)
 }
 
 /**

--- a/tests/SolidApi.test.js
+++ b/tests/SolidApi.test.js
@@ -1,16 +1,137 @@
 import auth from 'solid-auth-cli';
-import $rdf from 'rdflib';
 import SolidApi from '../src/SolidApi'
+import apiUtils from '../src/utils/apiUtils'
+
+const { LINK } = apiUtils
 
 const base = "file://" + process.cwd()
 const folder = base + "/test-folder/SolidApi/"
 const inexistentFolder = folder + "inexistent/"
+const inexistentFile = folder + "inexistent.abc"
+const turtleFile = folder + "turtle.ttl"
+const turtleFileContents = "<> a <#test>."
 
-const api = new SolidApi(auth.fetch.bind(auth), $rdf);
+const api = new SolidApi(auth.fetch.bind(auth));
 
 // Create container
 beforeAll(() => api.createFolder(folder))
+beforeAll(() => api.createFile(turtleFile, turtleFileContents, 'text/turtle'))
 
-test('deleteFolderContents throws response if folder doesn\'t exist', () => {
-  return expect(api.deleteFolderContents(inexistentFolder)).rejects.toHaveProperty('status', 404)
+describe('core methods', () => {
+  const coreFolder = folder + "core/"
+  const coreFile = coreFolder + "turtle.ttl"
+  const content = "<> a <#test>."
+  const contentType = "text/turtle"
+
+  const resetCoreFolder = async () => {
+    if (await api.itemExists(coreFolder)) {
+      await api.deleteFolderContents(coreFolder)
+    }
+    else {
+      await api.createFolder(coreFolder)
+    }
+    await api.createFile(coreFile, content, contentType)
+  }
+
+  beforeAll(resetCoreFolder)
+
+  describe('getters', () => {
+    const getters = {
+      fetch: api.fetch.bind(api),
+      get: api.get.bind(api),
+      head: api.head.bind(api),
+      // [Not yet supported by solid-auth-cli] options: api.options.bind(api),
+    }
+    for (const [name, method] of Object.entries(getters)) {
+      test(`${name} resolves with 200 for folder`, () => resolvesWithStatus(method(coreFolder), 200))
+      test(`${name} resolves with 200 for file`, () => resolvesWithStatus(method(coreFile), 200))
+      test(`${name} resolves with Content-Type text/turtle for folder`, () => resolvesWithHeader(method(coreFolder), "Content-Type", contentType))
+      test(`${name} resolves with Content-Type ${contentType} for file`, () => resolvesWithHeader(method(coreFile), "Content-Type", contentType))
+      test(`${name} rejects with 404 for inexistent folder`, () => rejectsWithStatus(method(inexistentFolder), 404))
+      test(`${name} rejects with 404 for inexistent file`, () => rejectsWithStatus(method(inexistentFile), 404))
+    }
+  })
+  
+  describe('creators', () => {
+    const dataFolder = coreFolder + "post/"
+    const fileName = "post.ttl"
+    const fileUrl = dataFolder + fileName
+    const folderName = "folder/"
+    const nestedFolderName = "nested/"
+    const nestedFolderUrl = dataFolder + "inexistent/path/" + nestedFolderName
+    const nestedFileName = "nested.ttl"
+    const nestedFileurl = nestedFolderUrl + nestedFileName
+    const nestedFileUrl = dataFolder + "nested/inexisting/path/"
+    const folderUrl = dataFolder + folderName
+    const usedFileName = "used.ttl"
+    const usedFileUrl = dataFolder + usedFileName
+    const usedFolderName = "used-folder/"
+    const usedFolderUrl = dataFolder + usedFolderName
+
+    const getPostOptions = (name) => {
+      return {
+        headers: {
+          slug: name,
+          link: name.endsWith('/') ? LINK.CONTAINER : LINK.RESOURCE
+        }
+      }
+    }
+
+    beforeAll(() => api.createFolder(dataFolder))
+    beforeEach(() => api.delete(fileUrl).catch(() => {}))
+    beforeEach(() => api.delete(folderUrl).catch(() => {}))
+    beforeEach(() => api.delete(nestedFolderUrl).catch(() => {}))
+    beforeEach(() => api.delete(nestedFileUrl).catch(() => {}))
+    beforeEach(() => api.post(dataFolder, getPostOptions(usedFileName)).catch(() => {}))
+    beforeEach(() => api.post(dataFolder, getPostOptions(usedFolderName)).catch(() => {}))
+
+    test('post resolves with 201 creating a new folder', () => resolvesWithStatus(api.post(dataFolder, getPostOptions(folderName)), 201))
+    test('post resolves with 201 creating a new file', () => resolvesWithStatus(api.post(dataFolder, getPostOptions(fileName)), 201))
+    test('post rejects with 404 on inexistent container', () => rejectsWithStatus(api.post(nestedFolderUrl, getPostOptions(nestedFileName)), 404))
+    test('post rejects with 409 overwriting a folder', () => rejectsWithStatus(api.post(dataFolder, getPostOptions(usedFolderName)), 409)) // TODO: Shouldn't this create a new folder instead?
+    // test('post rejects with xxx overwriting a file', () => resolvesWithHeader(api.post(postFolder, getOptions(usedFileName)), 201)) // TODO: Shouldn't this create a new file instead?
+
+    test('put resolves with 201 creating a new file', () => resolvesWithStatus(api.put(fileUrl), 201))
+    test('put resolves with 201 overwriting a file', () => resolvesWithStatus(api.put(usedFileUrl), 201))
+    test('put resolves with 201 creating a nested files', () => resolvesWithStatus(api.put(nestedFileUrl), 201))
+  })
 })
+
+describe('composed methods', () => {
+  describe('itemExists', () => {
+    test('itemExists resolves with true on existing file', () => expect(api.itemExists(turtleFile)).resolves.toBe(true))
+    test('itemExists resolves with true on existing folder', () => expect(api.itemExists(folder)).resolves.toBe(true))
+    test('itemExists resolves with false on inexistent file', () => expect(api.itemExists(inexistentFile)).resolves.toBe(false))
+    test('itemExists resolves with true on inexistent folder', () => expect(api.itemExists(inexistentFolder)).resolves.toBe(false))
+  })
+
+  // TODO: Add remaining methods...
+})
+
+
+/**
+ * @param {Promise<Response>} promise 
+ * @param {number} status https://jestjs.io/docs/en/setup-teardown
+ */
+function resolvesWithStatus(promise, status) {
+  return expect(promise).resolves.toHaveProperty('status', status)
+}
+
+/**
+ * @param {Promise<Response>} promise 
+ * @param {number} status 
+ */
+function rejectsWithStatus(promise, status) {
+  return expect(promise).rejects.toHaveProperty('status', status)
+}
+
+/**
+ * @param {Promise<Response>} promise
+ * @param {string} name
+ * @param {string} value
+ */
+async function resolvesWithHeader(promise, name, value) {
+  const response = await promise
+  const header = response.headers.get(name)
+  return expect(header).toMatch(value)
+}

--- a/tests/apiUtils.test.js
+++ b/tests/apiUtils.test.js
@@ -1,0 +1,66 @@
+import apiUtils from '../src/utils/apiUtils'
+import { exportAllDeclaration } from '@babel/types';
+
+const {
+    getParentUrl,
+    getItemName,
+    areFolders,
+    areFiles,
+} = apiUtils
+
+const host = 'https://example.org/'
+const base = host + 'path/to/'
+
+const files = [
+    base + 'file.ext',
+    base + 'file',
+    base + 'file-file'
+]
+const folders = [
+    base + 'folder/',
+    base + 'folder-two/'
+]
+
+describe('getParentUrl', () => {
+    test('getParentUrl returns parent if existing', () => {
+        const child = base + 'child/'
+        const grandChild = child + 'grand-child/'
+        expect(getParentUrl(grandChild)).toBe(child)
+        expect(getParentUrl(child)).toBe(base)
+    })
+    test('getParentUrl does not throw if no parent exists', () => {
+        getParentUrl(host)
+        getParentUrl('')
+        getParentUrl('/')
+    })
+})
+
+describe('getItemName', () => {
+    test('getItemName returns file name', () => {
+        const items = [
+            "file.ext",
+            "file",
+            "file-file.ext",
+        ]
+        items.forEach(name => expect(getItemName(base + name)).toBe(name))
+    })
+    test('getItemName returns folder name', () => {
+        const folders = [
+            "folder",
+            "folder-folder"
+        ]
+        folders.forEach(name => expect(getItemName(base + name + '/')).toBe(name))
+    })
+})
+
+describe('areFolders', () => {
+    test('returns true if all arguments are folders', () => expect(areFolders(...folders)).toBe(true))
+    test('returns false if some arguments are files', () => expect(areFolders(...folders, files[0])).toBe(false))
+    test('returns false if all arguments are files', () => expect(areFolders(...files)).toBe(false))
+})
+
+describe('areFiles', () => {
+    test('returns true if all arguments are files', () => expect(areFiles(...files)).toBe(true))
+    test('returns false if some arguments are folders', () => expect(areFiles(...files, folders[0])).toBe(false))
+    test('returns false if all arguments are folders', () => expect(areFiles(...folders)).toBe(false))
+})


### PR DESCRIPTION
  * to be consistent fetch now throws if response.ok is set to false
    I've updated methods in SolidFileClient to use get and handle thrown errors
  * added some tests for SolidApi
  * added tests for apiUtils 

In the tests I've encountered something unexpected regarding the post method: If I try to create a folder which already exists with post it responds with 409 instead of creating a new one. And trying to overwrite a file resolves with 201 but I don't see a new one being created. Is this something related to solid-auth-cli?