### PR TITLE
Add TestFolderGenerator and update SolidApi tests

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,28 +1,18 @@
-const fs = require("fs")
-const rimraf = require("rimraf");
+import { RootFolder } from './utils/TestFolderGenerator'
 
-const testContainerFolder = "./test-folder"
+const base = "file://" + process.cwd()
+const testContainer = new RootFolder(base, 'test-folder')
 
-function setup() {
-  return new Promise((resolve, reject) => {
-    // Remove the test folder
-    rimraf(testContainerFolder, err => {
-      try {
-        if (err) {
-          throw err
-        }
-        // Create an empty test folder
-        fs.mkdirSync(testContainerFolder)
-        return resolve()
-      }
-      catch (e) {
-        console.error("Error in setup.js: Couldn't reset test-folder")
-        console.trace()
-        console.error(e)
-        return reject(e)
-      }
-    })
-  })
+async function setup() {
+  try {
+    await testContainer.reset({ dryRun: false })
+  }
+  catch (e) {
+    console.error("Error in setup.js: Couldn't reset test-folder")
+    console.trace()
+    console.error(e)
+    throw e
+  }
 }
 
 export default setup

--- a/tests/utils/TestFolderGenerator.js
+++ b/tests/utils/TestFolderGenerator.js
@@ -1,0 +1,160 @@
+const fs = require('fs')
+const rimraf = require('rimraf')
+
+/**
+ * Class for creating test folder and file structures
+ * Don't create it directly. Use Folder/File/... instead
+ */
+class TestFolderGenerator {
+  /**
+   * Create a new item
+   * @param {string} name
+   * @param {string} content 
+   * @param {string} contentType 
+   * @param {TestFolderGenerator[]} children 
+   */
+  constructor(name, content, children) {
+    this.name = name
+    this.content = content
+    this.children = children
+  }
+
+  /**
+   * Delete folder and contents and then generate folder structure
+   * @param {object} [options] 
+   */
+  async reset(options = { dryRun: false }) {
+    await this.remove(options)
+    await this.generate(options)
+  }
+
+  /**
+   * Delete folder and contents
+   * @param {obejct} [options] 
+   */
+  async remove({ dryRun = false }) {
+    if (dryRun) {
+      console.log(`would remove ${this.path}`)
+      return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => rimraf(this.path, err => err ? reject(err) : resolve()))
+  }
+
+  /**
+   * Generate folder structure
+   * Will ignore items which already exists
+   * @param {object} options 
+   */
+  async generate(options = { dryRun: false }) {
+    try {
+      await ((this instanceof Folder) ? this._generateFolder(options) : this._generateFile(options))
+    }
+    catch (err) {
+      // Don't throw if the item already exists
+      if (err.code !== 'EEXIST') {
+        throw err
+      }
+    }
+
+    await Promise.all(this.children.map(child => child.generate(options)))
+  }
+
+  async _generateFolder({ dryRun }) {
+    if (dryRun) {
+      console.log(`would generate: ${this.path}`)
+      return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => fs.mkdir(this.path, err => err ? reject(err) : resolve()))
+  }
+
+  async _generateFile({ dryRun }) {
+    if (dryRun) {
+      console.log(`would generate: ${this.path}`)
+      return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => fs.writeFile(this.path, this.content, err => err ? reject(err) : resolve()))
+  }
+
+  /**
+   * 
+   * @param {string|TestFolderGenerator} base - either url starting with file:// path starting with / or instance of TestFolderGenerator 
+   */
+  setBase(base) {
+    if (base instanceof TestFolderGenerator) {
+      base = base.url
+      if (!base) {
+        throw new Error('The TestFolderGenerator supplied for setBase must already have a basePath')
+      }
+    }
+
+    this.basePath = base
+    if (!this.basePath.endsWith('/')) {
+      this.basePath = this.basePath + '/'
+    }
+
+    this.children.forEach(child => child.setBase(this.url))
+  }
+
+  get path() {
+    let path = this.url
+    
+    if (path.startsWith('file://')) {
+      path = path.substr('file://'.length)
+    }
+    return path
+  }
+
+  get url() {
+    if (typeof this.basePath !== 'string') {
+      throw new Error("Can't compute path because basePath is not set")
+    }
+    return this.basePath + this.name
+  }
+}
+
+class Folder extends TestFolderGenerator {
+  /**
+   * Create a new Test Folder
+   * @param {string} name 
+   * @param {TestFolderGenerator[]} [children] 
+   */
+  constructor(name, children = []) {
+    if (!name.endsWith('/')) {
+      name = name + '/'
+    }
+    super(name, '', children)
+  }
+}
+
+/**
+ * Shortcut to creating a new folder and calling folder.setBase(base)
+ */
+class RootFolder extends Folder {
+  /**
+   * 
+   * @param {string|TestFolderGenerator} base base path for all children
+   * @param {TestFolderGenerator[]} [children] 
+   */
+  constructor(base, name, children = []) {
+    super(name, children)
+    this.setBase(base)
+  }
+}
+
+class File extends TestFolderGenerator {
+  /**
+   * 
+   * @param {string} name 
+   * @param {string} content 
+   * @param {string} [contentType] 
+   */
+  constructor(name, content = "<> a <#test>.") {
+    super(name, content, [])
+  }
+}
+
+module.exports = {
+  Folder,
+  File,
+  RootFolder,
+}


### PR DESCRIPTION
I've added a new class which I'm using to generate folder structures (see example below).

The parsing still doesn't seem to work @jeff-zucker . If you comment out the deleteFolderContents test in line L117 in SolidApi.test.js you should see the error produced with the new version. 

```javascript
/** Example generating a testing folder structure
 * The generated structure is:
- SolidApi
- - my-test
- - - child
- - - - file1.ttl
- - - file2.ttl
 */

const base = "file://" + process.cwd() + "/test-folder/"
const container = new RootFolder(base, "SolidApi")
const fileOne = new File('file1.ttl', content)
const myTest = new RootFolder(container, 'my-test', [
  new Folder('child', [
    fileOne,
  ],
  new File('file2.ttl')
])

await myTest.reset() // Deletes my-test folder and then creates the folder structure

console.log('url for testing', myTest.url)
console.log('fileOne url', fileOne.url)
```
(Not tested, if you want a tested example I can write one later)
RootFolder creates a folder which already has a base path set. It will set the base path for all children automatically. Hence the `new Folder`s only need the name. If you want to use the url of a created file/folder, you'll need to store it as a variable and then pass it as parameter to a RootFolder (passing it to multiple root folders could break its base path, so only use it once). If you want to test out if the path works, you can pass it the `dryRun: true` option. 
If you think this is useful for you and want something better explained, just ask. I'll use it for my tests because it makes it easy to create sample directory structures for testing recursive methods. It should be able to implement it with a local storage version of solid-rest if desired (I'd prefer that because messing with the file system is always a bit risky, so I'll try to implement that at some time).