### PR TITLE
Update a few recursive tests

### DIFF
--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -267,6 +267,9 @@ class SolidAPI {
    * @returns {Promise<Response>} - Response from the new file created
    */
   async copyFile (from, to, options) {
+    if (typeof from !== 'string' || typeof to !== 'string') {
+      throw new Error(`The from and to parameters of copyFile must be strings. Found: ${from} and ${to}`)
+    }
     const response = await this.get(from)
     const content = await response.blob()
     const contentType = response.headers.get('content-type')
@@ -284,8 +287,10 @@ class SolidAPI {
    * The others will be creation responses from the contents in arbitrary order.
    */
   async copyFolder (from, to, options) {
-//    const { body: { folders, files } } = await this.readFolder(from)
-    const {folders,files} = await this.readFolder(from)
+    if (typeof from !== 'string' || typeof to !== 'string') {
+      throw new Error(`The from and to parameters of copyFile must be strings. Found: ${from} and ${to}`)
+    }
+    const { folders, files } = await this.readFolder(from)
     const folderResponse = await this.createFolder(to, options) // TODO: Consider separating into overwriteFiles and overwriteFolders
 
     const promises = [
@@ -333,7 +338,7 @@ class SolidAPI {
       ...files.map(async ({ url: fileUrl }) => this.delete(fileUrl))
     ])
 
-    return [].concat(deletionResults) // Flatten array
+    return [].concat(...deletionResults) // Flatten array
   }
 
   /**

--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -138,9 +138,9 @@ describe('composed methods', () => {
         test.todo('throws some kind of error when called on file')
         test('resolved array contains all names of the deleted items', async () => {
           const responses = await api.deleteFolderContents(parentFolder.url)
-          const names = responses.map(response => apiUtils.getItemName(response.headers.get('location')))
-          const expectedNames = parentFolder.contents.map(item => apiUtils.getItemName(item.url))
-          expect(names.sort()).toEqual(expectedNames.sort())
+          const urls = responses.map(response => response.url)
+          const expectedUrls = parentFolder.contents.map(item => item.url)
+          expect(urls.sort()).toEqual(expectedUrls.sort())
         })
         test('resolves with empty array on folder without contents', () => expect(api.deleteFolderContents(emptyFolder.url)).resolves.toHaveLength(0))
         test('after deletion itemExists returns false on all contents', async () => {
@@ -154,12 +154,12 @@ describe('composed methods', () => {
         test.todo('throws some kind of error when called on file')
         test('resolved array contains all names of the delete items', async () => {
           const responses = await api.deleteFolderRecursively(parentFolder.url)
-          const names = responses.map(response => apiUtils.getItemName(response.headers.get('location')))
-          const expectedNames = [
-            apiUtils.getItemName(parentFolder.url),
-            ...parentFolder.contents.map(item => apiUtils.getItemName(item.url))
+          const urls = responses.map(response => response.url)
+          const expectedUrls = [
+            parentFolder.url,
+            ...parentFolder.contents.map(item => item.url)
           ]
-          expect(names.sort()).toEqual(expectedNames.sort())
+          expect(urls.sort()).toEqual(expectedUrls.sort())
         })
         testIfHttps('after deletion itemExists returns false on folder and all contents', async () => {
           await api.deleteFolderRecursively(parentFolder.url)
@@ -172,11 +172,10 @@ describe('composed methods', () => {
     describe('copy', () => {
       describe('copyFile', () => {
         test('rejects with 404 on inexistent file', () => rejectsWithStatus(api.copyFile(inexistentFile.url, filePlaceholder.url), 404))
-        test.todo('throws some kind of error when called on folder')
-        test.todo('rejects if no second url is specified')
+        test('rejects if no second url is specified', () => expect(api.copyFile(childFile.url)).rejects.toBeDefined())
         // TODO: Change to test(...) when solid-rest supports blobs
-        testIfHttps('resolves with 201', () => resolvesWithStatus(api.copyFile(childFile.url, filePlaceholder.url), 201))
-        testIfHttps('resolves and has same content and contentType afterwards', async () => {
+        test('resolves with 201', () => resolvesWithStatus(api.copyFile(childFile.url, filePlaceholder.url), 201))
+        test('resolves and has same content and contentType afterwards', async () => {
           await resolvesWithStatus(api.copyFile(childFile.url, filePlaceholder.url), 201)
           await expect(api.itemExists(filePlaceholder.url)).resolves.toBe(true)
           const fromResponse = await api.get(childFile.url)
@@ -184,18 +183,19 @@ describe('composed methods', () => {
           expect(fromResponse.headers.get('Content-Type')).toBe(toResponse.headers.get('Content-Type'))
           expect(await fromResponse.text()).toBe(await toResponse.text())
         })
+        test.todo('throws some kind of error when called on folder')
         test.todo('test different configurations (overwrite, ...)')
       })
 
       describe('copyFolder', () => {
         test('rejects with 404 on inexistent folder', () => rejectsWithStatus(api.copyFolder(inexistentFolder.url, inexistentFolder.url), 404))
-        test.todo('throws some kind of error when called on file')
-        test.todo('rejects if no second url is specified')
-        testIfHttps('resolves with 201 and copies empty folder', async () => {
-          await resolvesWithStatus(api.copyFolder(emptyFolder.url, folderPlaceholder.url), 201)
+        test('rejects if no second url is specified', () => expect(api.copyFolder(emptyFolder.url)).rejects.toBeDefined())
+        test('resolves and copies empty folder', async () => {
+          await expect(api.copyFolder(emptyFolder.url, folderPlaceholder.url)).resolves.toBeDefined()
           await expect(api.itemExists(folderPlaceholder.url)).resolves.toBe(true)
         })
         test.todo('resolves with 201 and copies folder including its contents')
+        test.todo('throws some kind of error when called on file')
         test.todo('test different configurations (overwrite, ...')
       })
     })

--- a/tests/SolidApi.core.test.js
+++ b/tests/SolidApi.core.test.js
@@ -76,9 +76,10 @@ describe('core methods', () => {
       }
     }
 
-    let invalidSlugOptions = getPostOptions(newFolderPlaceholder.name)
+    const invalidSlugOptions = getPostOptions(newFolderPlaceholder.name)
     invalidSlugOptions.headers.slug += '/'
 
+    beforeAll(() => console.log('putUrl', usedFile.url))
     beforeEach(() => postFolder.reset())
 
     test('post resolves with 201 creating a new folder with valid slug', () => resolvesWithStatus(api.post(postFolder.url, getPostOptions(newFolderPlaceholder.name)), 201))
@@ -94,7 +95,7 @@ describe('core methods', () => {
   })
 
   describe('delete', () => {
-    const file = new File('turtle.tt')
+    const file = new File('turtle.ttl')
     const emptyFolder = new Folder('empty')
     const filledFolder = new Folder('filled', [
       file,

--- a/tests/testSetup.test.js
+++ b/tests/testSetup.test.js
@@ -1,5 +1,6 @@
 import { File, FolderPlaceholder, FilePlaceholder, BaseFolder } from './utils/TestFolderGenerator'
-import { getTestContainer, contextSetup } from './utils/contextSetup'
+import { getTestContainer, contextSetup, getFetch } from './utils/contextSetup'
+import SolidAPI from '../src/SolidApi'
 
 const inexistentFolder = new FolderPlaceholder('inexistent')
 const inexistentFile = new FilePlaceholder('inexistent.abc')
@@ -10,11 +11,22 @@ const container = new BaseFolder(getTestContainer(), 'setup-test', [
   turtleFile
 ])
 
+/** @type {SolidAPI} */
+let api
+
 beforeAll(async () => {
   await contextSetup()
-  await container.reset()
+  api = new SolidAPI(getFetch())
 })
+
+beforeEach(() => container.reset())
 
 describe('setup test', () => {
   test('true', () => expect(true).toBe(true))
+  test('container exists', () => expect(api.itemExists(container.url)).resolves.toBe(true))
+  test('can delete container', async () => {
+    await expect(api.delete(turtleFile.url)).resolves.toBeDefined()
+    await expect(api.delete(container.url)).resolves.toBeDefined()
+    return expect(api.itemExists(container.url)).resolves.toBe(false)
+  })
 })


### PR DESCRIPTION
I've updated some recursive tests (copy and delete). They rely on the PR I've made in solid-rest so with the current solid-rest versions these tests will fail for now. With the new one all pass.