### PR TITLE
Make jest https test work without authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "standard": {
     "globals": [
+      "jest",
       "test",
       "describe",
       "beforeAll",

--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -2,7 +2,7 @@ import SolidApi from '../src/SolidApi'
 import apiUtils from '../src/utils/apiUtils'
 import { Folder, File, FolderPlaceholder, FilePlaceholder, BaseFolder } from './utils/TestFolderGenerator'
 import { getFetch, getTestContainer, contextSetup } from './utils/contextSetup'
-import { rejectsWithStatus, resolvesWithStatus, testIfHttps } from './utils/jestUtils'
+import { rejectsWithStatus, resolvesWithStatus } from './utils/jestUtils'
 // import { resolvesWithHeader, resolvesWithStatus, rejectsWithStatus } from './utils/expectUtils'
 
 /** @type {SolidApi} */
@@ -16,6 +16,8 @@ const container = new BaseFolder(getTestContainer(), 'SolidApi-composed', [
   inexistentFolder,
   turtleFile
 ])
+
+jest.setTimeout(20 * 1000)
 
 beforeAll(async () => {
   await contextSetup()
@@ -310,7 +312,7 @@ describe('composed methods', () => {
       test('rejects with 404 on inexistent item', () => {
         return rejectsWithStatus(api.rename(inexistentFile.url, 'abc.txt'), 404)
       })
-  
+
       describe('rename file', () => {
         test('resolves with existing file', () => {
           return expect(api.rename(childFile.url, 'new-name.txt')).resolves.toBeDefined()

--- a/tests/SolidApi.core.test.js
+++ b/tests/SolidApi.core.test.js
@@ -18,6 +18,8 @@ const container = new BaseFolder(getTestContainer(), 'SolidApi-core', [
   turtleFile
 ])
 
+jest.setTimeout(20 * 1000)
+
 beforeAll(async () => {
   await contextSetup()
   api = new SolidApi(getFetch())

--- a/tests/SolidApi.core.test.js
+++ b/tests/SolidApi.core.test.js
@@ -73,7 +73,8 @@ describe('core methods', () => {
       return {
         headers: {
           slug,
-          link
+          link,
+          'Content-Type': 'text/turtle'
         }
       }
     }


### PR DESCRIPTION
Due to the error with jest and authenticated http requests, I've removed the auth.login call.

### Running http:// tests now:
- Create a folder in your pod (do it in /private/ if you don't want anyone to see)
- Give everyone read/write permissions
- Tweak the tests to run with https*
- Run `TEST_PREFIX=https:// TEST_BASE_URL=https://your-pod.solid.community/private/your-test-folder/ npx jest tests/SolidApi.composed.test.js`

*With tweaking I mean, that you can set `test.only` and `describe.only`, which makes jest only run these test(s) of the test suite. The https tests run slower, so it makes sense to only run what you really think is necessary. Also you can specify which test file to run with `jest tests/SolidApi.composed.test.js`. If you want to run all only write `jest` there.
Also you can change the "httpRequestsPerSecond" setting in contextSetup.js to a higher/lower value. I've it to 10 so we don't burden the solid.community server too much.

### Results
Everything in SolidApi.core.test.js would have passed if some bug fixes were made in NSS (I needed to add some additional '.ttl' extensions and the HEAD Content-Type [is broken](https://github.com/solid/node-solid-server/issues/454)).
In SolidApi.composed.test.js the itemExists, createFile and createFolder methods would have passed without NSS bugs. Everything relying on copyFile couldn't be tested because of the blob issue with isomorphic-fetch (see the roadmap issue).