### PR TITLE
corrections to readFolder : update solidApi._processStatements and rdf-query.loadFromUrl

### DIFF
--- a/src/utils/rdf-query.js
+++ b/src/utils/rdf-query.js
@@ -87,7 +87,7 @@ console.log( g )
  
 
   async loadFromUrl(url) {
-    const res = await this._fetch(url)
+    const res = await this._fetch(url, { headers: { "Accept": "text/turtle" }})   // needed for https://<podName>/ when there is an index.html
     if (!res.ok) {
       throw res
     }


### PR DESCRIPTION
update to : 
- `_processStatements` to return `type` with either `contentType` or `folder`
- add `{ headers: { "Accept": "text/turtle" }}` to `_fetch` in `rdf-query.loadFromUrl` (needed at podroot for fetch to return index.ttl else fetch returns index.html)

With this updates I made solid-ide working with solid-file-client 1.0.0 with minimal changes (
. load folder.content
. checksession returning webIId, it used to be session.webId)