### PR TITLE
Reject with all failed promises

### DIFF
--- a/src/utils/promiseUtils.js
+++ b/src/utils/promiseUtils.js
@@ -1,0 +1,40 @@
+/**
+ * @typedef {object} SettledPromise
+ * @property {("fulfilled"|"rejected")} status 
+ * @property {any} [value] Defined if the promise resolved
+ * @property {any} [reason] defined if the promise rejected
+ */
+
+/**
+ * 
+ * @param {Promise<any>[]} promises 
+ * @returns {Promise<SettledPromise[]>}
+ */
+async function promisesSettled(promises) {
+    const reflectedPromises = promises.map(promise => {
+        return promise
+            .then(value => { return { status: 'fulfilled', value } })
+            .catch(reason => { return { status: 'rejected', reason } })
+    })
+    return Promise.all(reflectedPromises)
+}
+
+/**
+ * Wait for all promises to finish and then reject with the rejected ones
+ * or resolve with the fulfilled ones
+ * @param {Promise<any>[]} promises 
+ * @returns {Promise<any>[]} resolved values of the promises
+ * @throws {any[]} reasons of the rejected promises
+ */
+async function promiseAllWithErrors(promises) {
+    const res = await promisesSettled(promises)
+    const errors = res.filter(({ status }) => status === 'rejected').map(({ reason }) => reason)
+    if (errors.length)
+        throw errors
+    return res.filter(({ status }) => status === 'fulfilled').map(({ value }) => value)
+}
+
+export default {
+    promiseAllWithErrors,
+    promisesSettled
+}

--- a/src/utils/promiseUtils.js
+++ b/src/utils/promiseUtils.js
@@ -34,7 +34,21 @@ async function promiseAllWithErrors(promises) {
     return res.filter(({ status }) => status === 'fulfilled').map(({ value }) => value)
 }
 
+/**
+ * Wait for all promises to finish. 
+ * If one or more rejects, create a flattened array of the errors and reject with it. 
+ * Else resolve with an array of the fulfilled ones
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<any>[]} resolved values of the promises
+ * @throws {any[]} reasons of the rejected promises
+ */
+async function promiseAllWithFlattenedErrors(promises) {
+    return promiseAllWithErrors(promises)
+        .catch(errors => { throw [].concat(...errors) })
+}
+
 export default {
     promiseAllWithErrors,
-    promisesSettled
+    promisesSettled,
+    promiseAllWithFlattenedErrors
 }

--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -229,7 +229,7 @@ describe('composed methods', () => {
           await expect(api.itemExists(`${parentFolder.url}${childFile.name}`)).resolves.toBe(true)
         })
         test('rejects when merging folders and files exist with option overwriteFiles=false', () => {
-          return expect(api.copyFolder(childOne.url, childTwo.url, { overwriteFiles: false })).rejects.toThrowError('already existed')
+          return expect(api.copyFolder(childOne.url, childTwo.url, { overwriteFiles: false })).rejects.toEqual(expect.arrayContaining([expect.any(Error)]))
         })
         test('deletes old contents when copying to an existing folder with overwriteFolders=true', async () => {
           await expect(api.copyFolder(childTwo.url, childOne.url, { overwriteFolders: true })).resolves.toBeDefined()
@@ -290,7 +290,7 @@ describe('composed methods', () => {
           return expect(api.move(childTwo.url, childOne.url)).resolves.toBeDefined()
         })
         test('rejects moving folder to existing folder with similar contents with overwriteFiles=false', async () => {
-          await expect(api.move(childTwo.url, childOne.url, { overwriteFiles: false })).rejects.toThrowError('already existed')
+          await expect(api.move(childTwo.url, childOne.url, { overwriteFiles: false })).rejects.toEqual(expect.arrayContaining([expect.any(Error)]))
           await expect(api.itemExists(childTwo.url)).resolves.toBe(true)
         })
         test('overwrites new folder contents and deletes old one', async () => {

--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -2,7 +2,7 @@ import SolidApi from '../src/SolidApi'
 import apiUtils from '../src/utils/apiUtils'
 import { Folder, File, FolderPlaceholder, FilePlaceholder, BaseFolder } from './utils/TestFolderGenerator'
 import { getFetch, getTestContainer, contextSetup } from './utils/contextSetup'
-import { rejectsWithStatus, resolvesWithStatus } from './utils/jestUtils'
+import { rejectsWithStatus, resolvesWithStatus, rejectsWithStatuses } from './utils/jestUtils'
 // import { resolvesWithHeader, resolvesWithStatus, rejectsWithStatus } from './utils/expectUtils'
 
 /** @type {SolidApi} */
@@ -140,7 +140,7 @@ describe('composed methods', () => {
 
     describe('delete', () => {
       describe('deleteFolderContents', () => {
-        test('rejects with 404 on inexistent folder', () => rejectsWithStatus(api.deleteFolderContents(inexistentFolder.url), 404))
+        test('rejects with 404 on inexistent folder', () => rejectsWithStatuses(api.deleteFolderContents(inexistentFolder.url), [404]))
         test.todo('throws some kind of error when called on file')
         test('resolved array contains all names of the deleted items', async () => {
           const responses = await api.deleteFolderContents(parentFolder.url)
@@ -156,7 +156,7 @@ describe('composed methods', () => {
       })
 
       describe('deleteFolderRecursively', () => {
-        test('rejects with 404 on inexistent folder', () => rejectsWithStatus(api.deleteFolderRecursively(inexistentFolder.url), 404))
+        test('rejects with 404 on inexistent folder', () => rejectsWithStatuses(api.deleteFolderRecursively(inexistentFolder.url), [404]))
         test.todo('throws some kind of error when called on file')
         test('resolved array contains all names of the delete items', async () => {
           const responses = await api.deleteFolderRecursively(parentFolder.url)
@@ -195,7 +195,7 @@ describe('composed methods', () => {
       })
 
       describe('copyFolder', () => {
-        test('rejects with 404 on inexistent folder', () => rejectsWithStatus(api.copyFolder(inexistentFolder.url, inexistentFolder.url), 404))
+        test('rejects with 404 on inexistent folder', async () => rejectsWithStatuses(api.copyFolder(inexistentFolder.url, inexistentFolder.url), [404]))
         test('rejects if no second url is specified', () => expect(api.copyFolder(emptyFolder.url)).rejects.toBeDefined())
         test('resolves and copies empty folder', async () => {
           await expect(api.copyFolder(emptyFolder.url, folderPlaceholder.url)).resolves.toBeDefined()
@@ -238,12 +238,13 @@ describe('composed methods', () => {
           await expect(api.itemExists(emptyFolder.url)).resolves.toBe(false) // Was only in  childOne
         })
         test.todo('throws some kind of error when called on file')
+        test.todo('throws flattened errors when it fails in multiple levels')
       })
     })
 
     describe('move', () => {
       test('rejects with 404 on inexistent item', () => {
-        return rejectsWithStatus(api.move(inexistentFile.url, filePlaceholder.url), 404)
+        return rejectsWithStatuses(api.move(inexistentFile.url, filePlaceholder.url), [404])
       })
 
       describe('moving file', () => {
@@ -310,7 +311,7 @@ describe('composed methods', () => {
 
     describe('rename', () => {
       test('rejects with 404 on inexistent item', () => {
-        return rejectsWithStatus(api.rename(inexistentFile.url, 'abc.txt'), 404)
+        return rejectsWithStatuses(api.rename(inexistentFile.url, 'abc.txt'), [404])
       })
 
       describe('rename file', () => {

--- a/tests/promiseUtils.test.js
+++ b/tests/promiseUtils.test.js
@@ -1,0 +1,51 @@
+import promiseUtils from '../src/utils/promiseUtils'
+
+const {
+  promiseAllWithErrors,
+  promisesSettled
+} = promiseUtils
+
+describe('promisesSettled', () => {
+  test('resolves when all promises resolve', () => {
+    return expect(promisesSettled([Promise.resolve(1), Promise.resolve(2)])).resolves.toBeDefined()
+  })
+  test('resolves when all promises reject', () => {
+    return expect(promisesSettled([Promise.reject(1), Promise.reject(2)])).resolves.toBeDefined()
+  })
+  test('resolves with array containing objects', async () => {
+    const res = await promisesSettled([
+      Promise.resolve('success'),
+      Promise.reject('error')
+    ])
+    expect(res).toHaveLength(2)
+    expect(res[0]).toHaveProperty('status', 'fulfilled')
+    expect(res[0]).toHaveProperty('value', 'success')
+    expect(res[1]).toHaveProperty('status', 'rejected')
+    expect(res[1]).toHaveProperty('reason', 'error')
+  })
+})
+
+describe('promiseAllWithErrors', () => {
+  test('resolves when all promises resolve', () => {
+    return expect(promiseAllWithErrors([Promise.resolve(1), Promise.resolve(2)])).resolves.toBeDefined()
+  })
+  test('rejects when all promises reject', () => {
+    return expect(promiseAllWithErrors([Promise.reject(1), Promise.reject(2)])).rejects.toBeDefined()
+  })
+  test('resolves with values', async () => {
+    const res = await promiseAllWithErrors([
+      Promise.resolve(1),
+      Promise.resolve(2)
+    ])
+    expect(res).toEqual(expect.arrayContaining([1, 2]))
+  })
+  test('rejects with reasons', async () => {
+    expect(promiseAllWithErrors([
+        Promise.resolve(1),
+        Promise.resolve(2),
+        Promise.reject('err1'),
+        Promise.reject('err2')
+      ])
+    ).rejects.toEqual(expect.arrayContaining(['err1', 'err2']))
+  })
+})

--- a/tests/promiseUtils.test.js
+++ b/tests/promiseUtils.test.js
@@ -1,8 +1,9 @@
 import promiseUtils from '../src/utils/promiseUtils'
 
 const {
+  promisesSettled,
   promiseAllWithErrors,
-  promisesSettled
+  promiseAllWithFlattenedErrors
 } = promiseUtils
 
 describe('promisesSettled', () => {
@@ -39,13 +40,40 @@ describe('promiseAllWithErrors', () => {
     ])
     expect(res).toEqual(expect.arrayContaining([1, 2]))
   })
-  test('rejects with reasons', async () => {
+  test('rejects with unflattened reasons', async () => {
     expect(promiseAllWithErrors([
         Promise.resolve(1),
         Promise.resolve(2),
         Promise.reject('err1'),
-        Promise.reject('err2')
+        Promise.reject('err2'),
+        Promise.reject(['err3', 'err4'])
       ])
-    ).rejects.toEqual(expect.arrayContaining(['err1', 'err2']))
+    ).rejects.toEqual(expect.arrayContaining(['err1', 'err2', ['err3', 'err4']]))
+  })
+})
+
+describe('promiseAllWithFlattenedErrors', () => {
+  test('resolves when all promises resolve', () => {
+    return expect(promiseAllWithFlattenedErrors([Promise.resolve(1), Promise.resolve(2)])).resolves.toBeDefined()
+  })
+  test('rejects when all promises reject', () => {
+    return expect(promiseAllWithFlattenedErrors([Promise.reject(1), Promise.reject(2)])).rejects.toBeDefined()
+  })
+  test('resolves with values', async () => {
+    const res = await promiseAllWithFlattenedErrors([
+      Promise.resolve(1),
+      Promise.resolve(2)
+    ])
+    expect(res).toEqual(expect.arrayContaining([1, 2]))
+  })
+  test('rejects with flattened array of reasons', async () => {
+    expect(promiseAllWithFlattenedErrors([
+        Promise.resolve(1),
+        Promise.resolve(2),
+        Promise.reject('err1'),
+        Promise.reject('err2'),
+        Promise.reject(['err3', 'err4'])
+      ])
+    ).rejects.toEqual(expect.arrayContaining(['err1', 'err2', 'err3', 'err4']))
   })
 })

--- a/tests/utils/jestUtils.js
+++ b/tests/utils/jestUtils.js
@@ -20,6 +20,20 @@ export function rejectsWithStatus (promise, status) {
 }
 
 /**
+ * @param {Promise<Response[]>} promise
+ * @param {number[]} statuses
+ */
+export async function rejectsWithStatuses (promise, statuses) {
+  try {
+    await promise
+    expect('expected rejection').toBe(undefined)
+  } catch (errors) {
+    expect(errors).toHaveLength(statuses.length)
+    errors.forEach((err, i) => expect(err).toHaveProperty('status', statuses[i]))
+  }
+}
+
+/**
  * @param {Promise<Response>} promise
  * @param {string} name
  * @param {string} value


### PR DESCRIPTION
This changes the error handling behavior of `copyFolder`, `deleteFolderContents` and all methods which use those (`move`, `rename`, `deleteFolderRecursively`). Previously they rejected with the first error, now they will wait for all promises to finish and reject with all found errors.

See https://github.com/jeff-zucker/solid-file-client/issues/52#issuecomment-552538851 for more background info