### PR TITLE
update responseErrToArray to HTTP/2

### DIFF
--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -731,7 +731,7 @@ class SolidAPI {
  * @param {Response|Error} err 
  */
 function responseErrToArray(err) {
-  if (err instanceof Error || !err.status || !err.statusText) {
+  if (err instanceof Error || !err.status) {
     throw err
   } else {
     throw [ err ]


### PR DESCRIPTION
response.statusText does not exist anymore in HTTP/2

see https://stackoverflow.com/questions/42401795/with-http-2-only-xmlhttprequest-responses-statustext-property-seems-to-be-us
and HTTP/2 spec

>  Finally, HTTP/2 simply doesn't have this property anymore, @JulianReschke pointed the right link in this other question I hadn't noticed before: greenbytes.de/tech/webdav/rfc7540.html#rfc.section.8.1.2.4.p.2 