### PR TITLE
Add SolidFileClient session mock tests

### DIFF
--- a/tests/SolidFileClient.session.test.js
+++ b/tests/SolidFileClient.session.test.js
@@ -1,0 +1,103 @@
+import SolidFileClient from '../src'
+
+const session = { webId: 'me' }
+const credentials = { todo: 'make this more realistic' }
+const defaultPopupUri = 'https://solid.community/common/popup.html'
+
+const mocks = {
+    login: jest.fn(),
+    logout: jest.fn(),
+    currentSession: jest.fn(),
+    popupLogin: jest.fn(),
+    getCredentials: jest.fn()
+}
+
+const auth = {}
+let fileClient
+
+// Reset fileClient and auth before each test
+beforeEach(() => {
+    auth.fetch = () => { throw new Error('Unexpected api call') }
+    Object.entries(mocks).forEach(([key, mockFunc]) => {
+        mockFunc.mockReset()
+        auth[key] = mockFunc
+    })
+    fileClient = new SolidFileClient(auth)
+})
+
+describe('login', () => {
+    test('login returns current session if available', async () => {
+        mocks.currentSession.mockResolvedValueOnce(session)
+        await expect(fileClient.login()).resolves.toBe(session.webId)
+    })
+    test('login calls login if no session available', async () => {
+        mocks.currentSession.mockResolvedValueOnce(null)
+        mocks.login.mockResolvedValueOnce(session)
+        await expect(fileClient.login(credentials)).resolves.toBe(session.webId)
+        expect(mocks.currentSession).toHaveBeenCalled()
+        expect(mocks.login).toHaveBeenCalledWith(credentials)
+    })
+    test.todo('test behaviour for a failed login')
+})
+
+describe('popupLogin', () => {
+    test('popupLogin returns current session if available', async () => {
+        mocks.currentSession.mockResolvedValueOnce(session)
+        await expect(fileClient.popupLogin()).resolves.toBe(session.webId)
+    })
+
+    test('popupLogin uses login if window is undefined', async () => {
+        mocks.login.mockResolvedValueOnce(session)
+        await expect(fileClient.popupLogin()).resolves.toBe(session.webId)
+        // TBD: Should login be called with the popupUri?
+        expect(mocks.login).toHaveBeenCalledWith(defaultPopupUri)
+    })
+
+    test.skip('popupLogin uses login if window is available', async () => {
+        // Note: If you know how to define window for one specific test case, please do this here :)
+        mocks.popupLogin.mockResolvedValueOnce(session)
+        await expect(fileClient.popupLogin()).resolves.toBe(session.webId)
+        expect(mocks.login).toHaveBeenCalledWith({ popupUri: defaultPopupUri })
+    })
+})
+
+describe('logout', () => {
+    test('logout forwards to mock logout', async () => {
+        mocks.logout.mockResolvedValueOnce(Promise.resolve())
+        await expect(fileClient.logout()).resolves.toBe()
+        expect(mocks.logout).toHaveBeenCalled()
+    })
+})
+
+describe('checkSession', () => {
+    test('returns webId if logged in', async () => {
+        mocks.currentSession.mockResolvedValueOnce(session)
+        await expect(fileClient.checkSession()).resolves.toBe(session.webId)
+        expect(mocks.currentSession).toHaveBeenCalled()
+    })
+    test('returns undefined if not logged in', async () => {
+        mocks.currentSession.mockResolvedValueOnce()
+        await expect(fileClient.checkSession()).resolves.not.toBeDefined()
+        expect(mocks.currentSession).toHaveBeenCalled()
+    })
+})
+
+describe('currentSession', () => {
+    test('currentSession forwards to mock', async () => {
+        mocks.currentSession.mockResolvedValueOnce(session)
+        await expect(fileClient.currentSession()).resolves.toBe(session)
+        expect(mocks.currentSession).toHaveBeenCalled()
+    })
+})
+
+describe('getCredentials', () => {
+    test('getCredentials forwards to mock', async () => {
+        mocks.getCredentials.mockReturnValueOnce(credentials)
+        expect(fileClient.getCredentials()).toBe(credentials)
+        expect(mocks.getCredentials).toHaveBeenCalled()
+    })
+})
+
+describe('trackSession', () => {
+    test.todo('Add test for this when it is implemented')
+})


### PR DESCRIPTION
I've added several test cases for the auth part of the SolidFileClient. It does pretty much the same as high-level-session.test.js but mocks the solid-auth-client so it can run in automated tests.

@jeff-zucker Would it be okay for you to rename/delete high-level-session.test.js so it doesn't automatically run with `npm test`? When we do this and upgrade to a new solid-rest version which includes https://github.com/jeff-zucker/solid-rest/pull/15, then all tests should pass again. I think setting up Travis CI would make sense now.

By the way, while making the tests I noticed two things: First, trackSession would be nice to have. Secondly, `popupLogin` calls `login(popupUri)` in a node environment, while I guess that login expects some kind of credentials.