### PR TITLE
Update error interface

### DIFF
--- a/examples/copy/index.html
+++ b/examples/copy/index.html
@@ -115,8 +115,6 @@
     <script src="../solid-auth-client/solid-auth-client.bundle.js"></script>
     <script src="../../dist/window/solid-file-client.bundle.js"></script>
     <script>
-        const { FetchError, ComposedFetchError } = SolidFileClient
-
         const fileClient = new SolidFileClient(solid.auth, { enableLogging: true })
 
         document.getElementById('login').addEventListener('click', e => fileClient.popupLogin())
@@ -184,8 +182,6 @@
                     addSuccessLog(msg)
                 })
             } catch (err) {
-                console.error(err)
-                addErrorLog(err.message)
                 err.rejectedErrors.forEach(err => {
                     console.error(err)
                     addErrorLog(err.message)

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import SolidFileClient from './SolidFileClient'
 import errorUtils from './utils/errorUtils'
 
-const { FetchError, ComposedFetchError } = errorUtils
+const { FetchError, SingleResponseError } = errorUtils
 SolidFileClient.FetchError = FetchError
-SolidFileClient.ComposedFetchError = ComposedFetchError
+SolidFileClient.SingleResponseError = SingleResponseError
 
 export default SolidFileClient

--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -9,8 +9,6 @@ import { rejectsWithStatuses, resolvesWithStatus, rejectsWithStatus } from './ut
 const { getFetch, getTestContainer, contextSetup } = contextSetupModule
 const { Folder, File, FolderPlaceholder, FilePlaceholder, BaseFolder } = TestFolderGenerator
 
-const { ComposedFetchError } = errorUtils
-
 /** @type {SolidApi} */
 let api
 
@@ -321,8 +319,8 @@ describe('composed methods', () => {
         test('resolves moving folder with depth 1 to folder with depth 1', () => {
           return expect(api.move(childTwo.url, childOne.url)).resolves.toBeDefined()
         })
-        test('rejects moving folder to existing folder with similar contents with overwriteFiles=false', async () => {
-          await expect(api.move(childTwo.url, childOne.url, { overwriteFiles: false })).rejects.toEqual(expect.any(ComposedFetchError))
+        test.only('rejects moving folder to existing folder with similar contents with overwriteFiles=false', async () => {
+          await expect(api.move(childTwo.url, childOne.url, { overwriteFiles: false })).rejects.toThrow(/already existed/)
           await expect(api.itemExists(childTwo.url)).resolves.toBe(true)
         })
         test('overwrites new folder contents and deletes old one', async () => {

--- a/tests/utils/jestUtils.js
+++ b/tests/utils/jestUtils.js
@@ -4,7 +4,7 @@
 import { getPrefix, prefixes } from './contextSetup'
 import SolidFileClient from '../../src'
 
-const { FetchError, ComposedFetchError } = SolidFileClient
+const { FetchError } = SolidFileClient
 
 /**
  * @param {Promise<Response>} promise
@@ -23,7 +23,7 @@ export async function rejectsWithStatus (promise, status) {
     await promise
     expect('promise did not reject').toBe(false)
   } catch (err) {
-    expect(err).toBeInstanceOf(ComposedFetchError)
+    expect(err).toBeInstanceOf(FetchError)
     expect(err.rejected).toHaveLength(1)
     expect(err.rejected[0]).toHaveProperty('status', status)
   }
@@ -38,7 +38,7 @@ export async function rejectsWithStatuses (promise, statuses) {
     await promise
     expect('promise did not reject').toBe(false)
   } catch (err) {
-    expect(err).toBeInstanceOf(ComposedFetchError)
+    expect(err).toBeInstanceOf(FetchError)
     err.rejected.forEach((res, i) => expect(res).toHaveProperty('status', statuses[i]))
   }
 }


### PR DESCRIPTION
See #84 for more background info.

All errors thrown now will be of the type FetchError which has these properties:
```
-> name (=SFCFetchError)
-> message (Human/Developer readable description. Includes status codes, statusTexts and for some errors solid specific explanations why it probably happened)
-> status (if only one response failed, this status; if multiple failed -2; if an other error ocured -1)
-> statusText (if only one response failed, this statusText; else same as message)
-> ok (=false)
-> successful (array of successful responses)
-> rejected (array of responses for failed requests)
-> rejectedErrors (array of SingleResponseErrors (has properties .response and .message)
-> errors (array errors not related to failed requests)
```