### PR TITLE
Update readFolder links

### DIFF
--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -11,12 +11,12 @@ const { FetchError, assertResponseOk, composedFetch, toFetchError } = errorUtils
 const { getLinksFromResponse, parseLinkHeader } = linksUtils
 const { parseFolderResponse } = folderUtils
 
-const MERGE = {
+export const MERGE = {
   REPLACE: 'replace',
   KEEP_SOURCE: 'source',
   KEEP_TARGET: 'target'
 }
-const LINKS = {
+export const LINKS = {
   EXCLUDE: 'exludeLinks',
   INCLUDE: 'includeLinks',
   INCLUDE_POSSIBLE: 'includePossibleLinks'

--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -405,7 +405,7 @@ class SolidAPI {
     const links = await this.head(url).then(getLinksFromResponse)
 
     if (options.links === LINKS.INCLUDE) {
-      this._removeInexistingLinks(links)
+      await this._removeInexistingLinks(links)
     }
 
     return links

--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -51,11 +51,18 @@ const defaultSolidApiOptions = {
 }
 
 /**
- * @typedef Item
+ * @typedef {object} Links
+ * @property {string} [acl]
+ * @property {string} [meta]
+ */
+
+/**
+ * @typedef {object} Item
  * @property {string} url
  * @property {string} name
  * @property {string} parent
  * @property {"Container" | "Resource"} itemType
+ * @property {Links} [links]
  */
 
 /**
@@ -63,6 +70,7 @@ const defaultSolidApiOptions = {
  * @property {string} url
  * @property {string} name
  * @property {string} parent
+ * @property {Links} links
  * @property {"folder"} type
  * @property {Item[]} folders
  * @property {Item[]} files
@@ -234,10 +242,6 @@ class SolidAPI {
       })
   }
 
-  async getItemLinks (url) {
-    return this.head(url).then(getLinksFromResponse)
-  }
-
   /**
    * Create an item at target url.
    * Per default it will create the parent folder if it doesn't exist.
@@ -365,7 +369,6 @@ class SolidAPI {
    * @returns {Promise<FolderData>}
    * @throws {FetchError}
    */
-
   async readFolder (url, options) {
     url = url.endsWith('/') ? url : url + '/'
     options = {
@@ -374,54 +377,58 @@ class SolidAPI {
     }
 
     const folderRes = await this.get(url, { headers: { Accept: 'text/turtle' } })
-    const parsed = parseFolderResponse(folderRes, url)
+    const parsed = await parseFolderResponse(folderRes, url)
 
     if (options.links === LINKS.INCLUDE_POSSIBLE || options.links === LINKS.INCLUDE) {
-      await this._addPossibleLinks(parsed)
-    }
-
-    if (options.links === LINKS.INCLUDE) {
-      await this._removeInexistingLinks(parsed)
+      const addItemLinks = async item => item.links = await this.getItemLinks(item.url, options)
+      await composedFetch([
+        ...(options.links === LINKS.INCLUDE ? [this._removeInexistingLinks(parsed.links)] : []),
+        ...parsed.files.map(addItemLinks),
+        ...parsed.folders.map(addItemLinks)
+      ])
     }
 
     return parsed
   }
 
   /**
-   * Add all links for files and folders found by getItemLinks
-   * @param {FolderData} folderData
-   * @private
+   * Get acl and meta links of an item
+   * @param {string} url
+   * @param {object} [options] specify if links should be checked for existence or not
+   * @returns {Promise<Links>}
    */
-  async _addPossibleLinks (folderData) {
-    const addPossibleLinks = async item => item.links = await this.getItemLinks(item.url)
-    await composedFetch([
-      ...folderData.files.map(addPossibleLinks),
-      ...folderData.folders.map(addPossibleLinks)
-    ])
+  async getItemLinks (url, options = { links: INCLUDE_POSSIBLE }) {
+    if (options.links === LINKS.EXCLUDE) {
+      toFetchError(new Error('Invalid option LINKS.EXCLUDE for getItemLinks'))
+    }
+
+    const links = await this.head(url).then(getLinksFromResponse)
+
+    if (options.links === LINKS.INCLUDE) {
+      this._removeInexistingLinks(links)
+    }
+
+    return links
   }
 
   /**
-   * Remove all links in files and folders which don't exist
-   * @param {FolderData} folderData
+   * Remove all links which are not existing of a links object
+   * @param {Links} links
+   * @returns {Promise<void>}
    * @private
    */
-  async _removeInexistingLinks (folderData) {
-    const removeInexistingLinks = item => composedFetch(
-      Object.entries(item.links)
-        .map(([type, url]) => {
-          return this.itemExists(url).catch(err => false)
-            .then(exists => {
-              if (!exists) {
-                delete item.links[type]
-              }
-            })
-        })
+  async _removeInexistingLinks (links) {
+    await composedFetch(
+      Object.entries(links)
+        .map(([type, url]) => this.itemExists(url)
+          .catch(err => false)
+          .then(exists => {
+            if (!exists) {
+              delete links[type]
+            }
+          })
+        )
     )
-
-    await composedFetch([
-      ...folderData.files.map(removeInexistingLinks),
-      ...folderData.folders.map(removeInexistingLinks)
-    ])
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,12 @@
 import SolidFileClient from './SolidFileClient'
+import { MERGE, LINKS } from './SolidApi'
 import errorUtils from './utils/errorUtils'
 
+// Consider adding these as static properties to SolidApi
 const { FetchError, SingleResponseError } = errorUtils
 SolidFileClient.FetchError = FetchError
 SolidFileClient.SingleResponseError = SingleResponseError
+SolidFileClient.LINKS = LINKS
+SolidFileClient.MERGE = MERGE
 
 export default SolidFileClient

--- a/src/utils/folderUtils.js
+++ b/src/utils/folderUtils.js
@@ -92,6 +92,7 @@ function _processStatements (url, stmts) {
 function _packageFolder (folderUrl, folderLinks, folderItems, fileItems) {
   const returnVal = {}
   returnVal.type = 'folder' // for backwards compatability :-(
+  returnVal.itemType = 'Container'
   returnVal.name = getItemName(folderUrl)
   returnVal.parent = getParentUrl(folderUrl)
   returnVal.url = folderUrl

--- a/src/utils/linksUtils.js
+++ b/src/utils/linksUtils.js
@@ -25,20 +25,24 @@ function _parseLinkHeaderToArray (linkHeader) {
 }
 
 /**
- * Parse all links from a link header into an object
+ * Parse acl and meta links from a link header into an object
  * @param {string} linkHeader
  * @param {string} itemUrl
- * @returns {object} rel as keys, urls as values
+ * @returns {object} rel as keys, urls as values. If not found, the key is not set
  */
 function parseLinkHeader (linkHeader, itemUrl) {
   const results = {}
-  const links = _parseLinkHeaderToArray(linkHeader)
-  links.forEach(link => {
-    // link is similar to: <file.txt.acl>; rel="acl",
-    const url = link.substring(link.indexOf('<') + 1, link.indexOf('>'))
-    const rel = link.substring(link.indexOf('rel="') + 'rel="'.length, link.lastIndexOf('"'))
-    results[rel] = _urlJoin(url, itemUrl)
-  })
+  _parseLinkHeaderToArray(linkHeader)
+    .map(link => {
+      // link is similar to: <file.txt.acl>; rel="acl",
+      const url = link.substring(link.indexOf('<') + 1, link.indexOf('>'))
+      const originalRel = link.substring(link.indexOf('rel="') + 'rel="'.length, link.lastIndexOf('"'))
+      const rel = originalRel.toLowerCase() === 'describedby' ? 'meta' : originalRel // Map describedBy to meta
+      return [rel, url]
+    })
+    .filter(([rel]) => ['meta', 'acl'].includes(rel))
+    .forEach(([rel, url]) => results[rel] = _urlJoin(url, itemUrl))
+
   return results
 }
 


### PR DESCRIPTION
readFolder now works with the flags (exclude as default, include and includePossible). I've added an automated test which covers some of the behavior and also tried it out manually in the browser.

Questions that remain open:
- If the top folder has a meta file NSS adds it to the files. So existing meta files currently are in links and files. I'd leave it like that.
- Should we fail if a request to a link or file in the folder fails? In particular to get possible or existing links. Currently I've implemented it to ignore errors when checking if a link exists, errors when getting possible links are thrown I think. I didn't think much about this though.

Usage:
```javascript
const { LINKS } = SolidFileClient
await fc.readFolder(url) // defaults to LINKS.EXCLUDE
await fc.readFolder(url, { links: LINKS.EXCLUDE })
await fc.readFolder(url, { links: LINKS.INCLUDE })
await fc.readFolder(url, { links: LINKS.INCLUDE_POSSIBLE })
await fc.readFolder(url, { links: SolidFileClient.LINKS.EXCLUDE })
// Also possible but not suggested because it's easier to make typos: 
await fc.readFolder(url, { links: 'excludeLinks' })
```