### PR TITLE
Update acl and merge behavior

### DIFF
--- a/src/SolidFileClient.js
+++ b/src/SolidFileClient.js
@@ -46,11 +46,7 @@ class SolidFileClient extends SolidApi {
 
   readHead (url, options) { return super.head(url, options) }
 
-  async deleteFile (url) {
-    const links = await this.getItemLinks(url)
-    if (links.acl) this.delete(links.acl)
-    return this.delete(url)
-  }
+  async deleteFile (url) { return super._deleteItemWithLinks(url) }
 
   async deleteFolder (url, options) { return super.deleteFolderRecursively(url) }
 }

--- a/src/utils/errorUtils.js
+++ b/src/utils/errorUtils.js
@@ -81,7 +81,7 @@ const defaultErrorDescriptions = {
  * Throw response if response.ok is set to false
  * @param {Response} res
  * @returns {Response} same response
- * @throws {Response}
+ * @throws {FetchError}
  */
 function assertResponseOk (res) {
   if (!res.ok) {

--- a/src/utils/folderUtils.js
+++ b/src/utils/folderUtils.js
@@ -16,7 +16,6 @@ const parseFolderResponse = async (folderResponse, folderUrl = folderResponse.ur
 
   const rdf = new RdfQuery()
   const files = await rdf.queryTurtle(folderUrl, turtle, { thisDoc: '' }, { ldp: 'contains' })
-  const folderLinks = getLinksFromResponse(folderResponse)
 
   const folderItems = []
   const fileItems = []
@@ -32,7 +31,7 @@ const parseFolderResponse = async (folderResponse, folderUrl = folderResponse.ur
     }
   }))
 
-  return _packageFolder(folderUrl, folderLinks, folderItems, fileItems)
+  return _packageFolder(folderUrl, folderItems, fileItems)
 }
 
 /**
@@ -84,19 +83,17 @@ function _processStatements (url, stmts) {
 /**
  * @private
  * @param {string} folderUrl
- * @param {Object.<string, string>} folderLinks
  * @param {Item[]} folderItems
  * @param {Item[]} fileItems
  * @returns {FolderData}
  */
-function _packageFolder (folderUrl, folderLinks, folderItems, fileItems) {
+function _packageFolder (folderUrl, folderItems, fileItems) {
   const returnVal = {}
   returnVal.type = 'folder' // for backwards compatability :-(
   returnVal.itemType = 'Container'
   returnVal.name = getItemName(folderUrl)
   returnVal.parent = getParentUrl(folderUrl)
   returnVal.url = folderUrl
-  returnVal.links = folderLinks
   returnVal.folders = folderItems
   returnVal.files = fileItems
 

--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -1,5 +1,5 @@
 
-import SolidApi from '../src/SolidApi'
+import SolidApi, { MERGE } from '../src/SolidApi'
 import apiUtils from '../src/utils/apiUtils'
 import TestFolderGenerator from './utils/TestFolderGenerator'
 import contextSetupModule from './utils/contextSetup'
@@ -161,11 +161,11 @@ describe('composed methods', () => {
       filePlaceholder,
       folderPlaceholder
     ])
-    const deleteFolder = new BaseFolder(container, 'delete', [
+    const nestedFolder = new BaseFolder(container, 'delete', [
       parentFolder
     ])
 
-    beforeEach(() => deleteFolder.reset())
+    beforeEach(() => nestedFolder.reset())
 
     describe('delete', () => {
       describe('deleteFolderContents', () => {
@@ -252,19 +252,20 @@ describe('composed methods', () => {
           await expect(api.itemExists(folderPlaceholder.url)).resolves.toBe(true)
           // Note: Could test for others to exist too
         })
-        test('merges folders when copying to an already existing folder', async () => {
-          await expect(api.copyFolder(childOne.url, parentFolder.url)).resolves.toBeDefined()
-          await expect(api.itemExists(`${parentFolder.url}${emptyFolder.name}/`)).resolves.toBe(true)
-          await expect(api.itemExists(`${parentFolder.url}${childFile.name}`)).resolves.toBe(true)
+        test('replaces existing folders per default', async () => {
+          await expect(api.copyFolder(childTwo.url, childOne.url)).resolves.toBeDefined()
+          await expect(api.itemExists(emptyFolder.url)).resolves.toBe(false) // empty folder was only in childOne
+          await expect(api.itemExists(childFile.url)).resolves.toBe(true) // childFile is in both
         })
-        test('rejects when merging folders and files exist with option overwriteFiles=false', () => {
-          return expect(api.copyFolder(childOne.url, childTwo.url, { overwriteFiles: false })).rejects.toThrow(/already existed/)
+        test('overwrites files from target folder with merge=KEEP_SOURCE', async () => {
+          await expect(api.copyFolder(childTwo.url, childOne.url, { merge: MERGE.KEEP_SOURCE })).resolves.toBeDefined()
+          await expect(api.itemExists(emptyFolder.url)).resolves.toBe(true)
+          await expect(api.get(childFile.url).then(res => res.text())).resolves.toBe(childFileTwo.content)
         })
-        test('deletes old contents when copying to an existing folder with overwriteFolders=true', async () => {
-          await expect(api.copyFolder(childTwo.url, childOne.url, { overwriteFolders: true })).resolves.toBeDefined()
-          await expect(api.itemExists(childOne.url)).resolves.toBe(true)
-          await expect(api.itemExists(childFile.url)).resolves.toBe(true) // Was in childTwo and childOne
-          await expect(api.itemExists(emptyFolder.url)).resolves.toBe(false) // Was only in  childOne
+        test('keeps files from target folder with merge=KEEP_TARGET', async () => {
+          await expect(api.copyFolder(childTwo.url, childOne.url, { merge: MERGE.KEEP_TARGET })).resolves.toBeDefined()
+          await expect(api.itemExists(emptyFolder.url)).resolves.toBe(true)
+          await expect(api.get(childFile.url).then(res => res.text())).resolves.toBe(childFile.content)
         })
         test.todo('throws some kind of error when called on file')
         test.todo('throws flattened errors when it fails in multiple levels')
@@ -318,9 +319,9 @@ describe('composed methods', () => {
         test('resolves moving folder with depth 1 to folder with depth 1', () => {
           return expect(api.move(childTwo.url, childOne.url)).resolves.toBeDefined()
         })
-        test('rejects moving folder to existing folder with similar contents with overwriteFiles=false', async () => {
-          await expect(api.move(childTwo.url, childOne.url, { overwriteFiles: false })).rejects.toThrow(/already existed/)
-          await expect(api.itemExists(childTwo.url)).resolves.toBe(true)
+        test('resolves moving folder to existing folder with similar contents with merge=KEEP_TARGET', async () => {
+          await expect(api.move(childTwo.url, childOne.url, { merge: MERGE.KEEP_TARGET })).resolves.toBeDefined()
+          await expect(api.itemExists(childTwo.url)).resolves.toBe(false)
         })
         test('overwrites new folder contents and deletes old one', async () => {
           await expect(api.move(childOne.url, childTwo.url)).resolves.toBeDefined()

--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -71,15 +71,15 @@ describe('composed methods', () => {
         await resolvesWithStatus(api.createFolder(usedFolder.url), 200)
         await expect(api.itemExists(fileInUsedFolder.url)).resolves.toBe(true)
       })
-      test.skip('resolves with 201 on existing folder with options.overwriteFolders and is empty afterwards', async () => {
-        await resolvesWithStatus(api.createFolder(usedFolder.url, { overwriteFolders: true }), 201)
+      test('resolves with 201 on existing folder with merge=REPLACE and is empty afterwards', async () => {
+        await resolvesWithStatus(api.createFolder(usedFolder.url, { merge: MERGE.REPLACE }), 201)
         await expect(api.itemExists(fileInUsedFolder.url)).resolves.toBe(false)
       })
       test('resolves with 201 on inexistent folder with parent', () => {
         return resolvesWithStatus(api.createFolder(folderPlaceholder.url), 201)
       })
       test('resolves with 201 on inexistent folder with parent and options.createPath=false', () => {
-        return resolvesWithStatus(api.createFolder(folderPlaceholder.url), 201)
+        return resolvesWithStatus(api.createFolder(folderPlaceholder.url, { createPath: false }), 201)
       })
       test('resolves with 201 on inexistent folder without parent', () => {
         return resolvesWithStatus(api.createFolder(nestedFolderPlaceholder.url), 201)
@@ -99,17 +99,14 @@ describe('composed methods', () => {
         expect(await res.text()).toBe(content)
         expect(await res.headers.get('content-type')).toMatch(contentType)
       })
-      test('rejects on existing file if options.overwriteFiles=false', () => {
-        return expect(api.createFile(usedFile.url, content, contentType, { overwriteFiles: false })).rejects.toBeDefined()
+      test('rejects on existing file if merge=KEEP_TARGET', () => {
+        return expect(api.createFile(usedFile.url, content, contentType, { merge: MERGE.KEEP_TARGET })).rejects.toBeDefined()
       })
       test('resolves with 201 on inexistent file', () => {
         return resolvesWithStatus(api.createFile(filePlaceholder.url, content, contentType), 201)
       })
       test('resolves with 201 on inexistent nested file', () => {
         return resolvesWithStatus(api.createFile(nestedFilePlaceholder.url, content, contentType), 201)
-      })
-      test.skip('rejects with 404 on inexistent nested file with options.createPath=false', () => {
-        return rejectsWithStatus(api.createFile(nestedFilePlaceholder.url, content, contentType, { createPath: false }), 404)
       })
       test.todo('Add tests for binary files (images, audio, ...)')
     })
@@ -124,17 +121,14 @@ describe('composed methods', () => {
         expect(await res.text()).toBe(content)
         expect(await res.headers.get('content-type')).toMatch(contentType)
       })
-      test('rejects on existing file if options.overwriteFiles=false', () => {
-        return expect(api.putFile(usedFile.url, content, contentType, { overwriteFiles: false })).rejects.toBeDefined()
+      test('rejects on existing file if merge=KEEP_TARGET', () => {
+        return expect(api.putFile(usedFile.url, content, contentType, { merge: MERGE.KEEP_TARGET })).rejects.toBeDefined()
       })
       test('resolves with 201 on inexistent file', () => {
         return resolvesWithStatus(api.putFile(filePlaceholder.url, content, contentType), 201)
       })
       test('resolves with 201 on inexistent nested file', () => {
         return resolvesWithStatus(api.putFile(nestedFilePlaceholder.url, content, contentType), 201)
-      })
-      test.skip('rejects on inexistent nested file with options.createPath=false', () => {
-        return expect(api.putFile(nestedFilePlaceholder.url, content, contentType, { createPath: false })).rejects.toBeDefined()
       })
       test.todo('Add tests for binary files (images, audio, ...)')
     })
@@ -217,8 +211,8 @@ describe('composed methods', () => {
           expect(fromResponse.headers.get('Content-Type')).toBe(toResponse.headers.get('Content-Type'))
           expect(await fromResponse.text()).toBe(await toResponse.text())
         })
-        test('rejects when copying to existent file with overwriteFiles=false', () => {
-          return expect(api.copyFile(childFile.url, childFileTwo.url, { overwriteFiles: false })).rejects.toThrowError('already existed')
+        test('rejects when copying to existent file with merge=KEEP_TARGET', () => {
+          return expect(api.copyFile(childFile.url, childFileTwo.url, { merge: MERGE.KEEP_TARGET })).rejects.toThrowError('already existed')
         })
         test.todo('throws some kind of error when called on folder')
       })
@@ -286,8 +280,8 @@ describe('composed methods', () => {
         test('resolves moving existing to existing file', () => {
           return expect(api.move(childFile.url, parentFile.url)).resolves.toBeDefined()
         })
-        test('rejects moving existing to existing file with overwriteFiles=false', async () => {
-          await expect(api.move(childFile.url, parentFile.url, { overwriteFiles: false })).rejects.toThrowError('already existed')
+        test('rejects moving existing to existing file with merge=KEEP_TARGET', async () => {
+          await expect(api.move(childFile.url, parentFile.url, { merge: MERGE.KEEP_TARGET })).rejects.toThrowError('already existed')
           await expect(api.itemExists(childFile.url)).resolves.toBe(true)
         })
         test('overwrites new location and deletes old one', async () => {

--- a/tests/SolidApi.readFolder.test.js
+++ b/tests/SolidApi.readFolder.test.js
@@ -39,10 +39,6 @@ const sampleFolderWithoutLinks = {
     name: folderName,
     parent: parentUrl,
     url: folderUrl,
-    links: {
-        acl: `${folderUrl}.acl`,
-        meta: `${folderUrl}.meta`
-    },
     folders: [
         {
             type: 'folder',
@@ -65,6 +61,10 @@ const sampleFolderWithoutLinks = {
 
 const sampleFolderObj = {
     ...sampleFolderWithoutLinks,
+    links: {
+        acl: `${folderUrl}.acl`,
+        meta: `${folderUrl}.meta`
+    },
     folders: [
         {
             ...sampleFolderWithoutLinks.folders[0],
@@ -141,7 +141,7 @@ const api = new SolidApi(sampleFetch)
 
 describe('readFolder', () => {
     describe('EXCLUDE links', () => {
-        test('can read sampleFolder', async () => {
+        test('can read sample folder', async () => {
             const res = await api.readFolder(sampleFolderObj.url)
             expect(res).toEqual(sampleFolderWithoutLinks)
             expect(sampleFetch).toHaveBeenCalledTimes(1)
@@ -149,18 +149,18 @@ describe('readFolder', () => {
     })
 
     describe('INCLUDE links', () => {
-        test('does not throw', async () => {
+        test('can read sample folder with existing links', async () => {
             const res = await api.readFolder(sampleFolderObj.url, { links: 'includeLinks' })
             expect(res).toEqual(sampleFolderObj)
-            expect(sampleFetch).toHaveBeenCalledTimes(1 + 2 + 6)
+            expect(sampleFetch).toHaveBeenCalledTimes(1 + 3 + 6)
         })
     })
 
     describe('INCLUDE_POSSIBLE links', () => {
-        test('does not throw', async () => {
+        test('can read sample folder with possible links', async () => {
             const res = await api.readFolder(sampleFolderObj.url, { links: 'includePossibleLinks' })
             expect(res).toEqual(sampleFolderObjWithPossibleLinks)
-            expect(sampleFetch).toHaveBeenCalledTimes(1 + 2)
+            expect(sampleFetch).toHaveBeenCalledTimes(1 + 3)
         })
     })
 


### PR DESCRIPTION
I've implemented the merge options for createFolder and putFile and the copy methods simply pass on this option. I've removed overwriteFiles and overwriteFolders because it seemed to confusing to have this and the merge options.

Usage:
```javascript
const { MERGE } = SolidFileClient
await fc.copy(from, to) // Defaults to replace
await fc.copy(from, to, { merge: MERGE.REPLACE }) // Delete target before copying
await fc.copy(from, to, { merge: MERGE.KEEP_SOURCE }) // Overwrite files in target, keep target folder
await fc.copy(from, to, { merge: MERGE.KEEP_TARGET }) // Will not overwrite existing files

// I made it work this way because it is easy to implement.
// If you want you can document it, but it's not necessary
await fc.putFile(..., { merge: MERGE.REPLACE }) // Default PUT behavior
await fc.putFile(..., { merge: MERGE.KEEP_SOURCE }) // Default PUT behavior
await fc.putFile(..., { merge: MERGE.KEEP_TARGET }) // Throw if target exist, else PUT
await fc.createFolder(url) // Ensures that the folder exist
await fc.createFolder(url, { merge: MERGE.REPLACE }) // Deletes the folder if it exists, then creates a new one
await fc.copyFile(from, to, { merge: REPLACE }) // default
await fc.copyFile(from, to, { merge: KEEP_TARGET }) // Throw if target exist, else copy
```

withAcl should also work for copying and deleting now, but it's not tested at all (neither with automated tests, nor with manual testing). I won't have time for this today, if you want you can test it out.

And readFolder now doesn't include the possible links of the top folder per default.

> To make it short (nothing rough) I will always exclude links from array folders, as I do not see any use case.
All uses case of links (existing or possible) in readFolder(foo/) that I think of are on the container level itself. And not in the next down level :

>    foo/ is see uses case for links foo/.acl and foo/.meta
    but for foo/bar/ links foo/bar/.acl or foo/bar/.meta I do not see any. I shall see them in readFolder(foo/bar/)
    foo/test.ttl links are at the container foo/ level foo/test.ttl..acl so I see uses case

Ok, now I understand what you mean. What are the use cases you see for this? I currently don't see many use cases for readFolder with links in both cases. 