### PR TITLE
Add core-js 3 for babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,8 @@
     [
       "@babel/preset-env",
       {
-        "useBuiltIns": "entry"
+        "useBuiltIns": "usage",
+        "corejs": "3.0.0"
       }
     ]
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3565,6 +3565,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
+      "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q=="
+    },
     "core-js-compat": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.2.tgz",
@@ -8085,10 +8090,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.3.3.tgz",
-      "integrity": "sha512-ZDUJFB9CpnPuWJA75ONOukLKFV762o5Qhl6SvqjvDb+NP6x9WJ/b1L3GUtXXkbwRTCdVVQfmC/vDhgKs7uBR5w==",
-      "dev": true
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.3.5.tgz",
+      "integrity": "sha512-McWb1tCWGGAmHeGEakqZj/UqxQR9cpEYZ/JivBj59YfiOAuaIWZxu0B+jnhbCwCZ2AsxdgQ5Dq8fehIJpYQaMQ=="
     },
     "nan": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "babel-loader": "^8.0.0-beta.6",
     "jest": "^24.9.0",
     "jsdoc-to-markdown": "^5.0.3",
-    "n3": "^1.3.3",
     "regenerator-runtime": "^0.13.3",
     "solid-auth-cli": "^1.0.10",
     "solid-namespace": "^0.2.0",
@@ -68,6 +67,8 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "debug": "^4.1.1"
+    "core-js": "^3.6.0",
+    "debug": "^4.1.1",
+    "n3": "^1.3.5"
   }
 }


### PR DESCRIPTION
I've installed core-js 3 and set the config in .babelrc. I've also changed `useBuiltIns` to "usage". If I understood it correctly this means, that babel will take care of adding polyfills of methods we used.

I've also moved n3 to dependencies as it is definitely needed for our program to work.