### PR TITLE
Fix file:// tests

### DIFF
--- a/tests/utils/FileApi.js
+++ b/tests/utils/FileApi.js
@@ -1,5 +1,7 @@
 import fs from 'fs'
 
+// Note: Errors here should be thrown in a way that they work for TestFolderGenerator
+//       For instance, TestFolderGenerator._removeFile checks if the response status is 404, so delete has to return 404 if it didn't exist
 class FileApi {
     constructor(prefix) {
         this._prefix = prefix
@@ -18,6 +20,7 @@ class FileApi {
     }
     delete(url) {
         return fs.promises.unlink(this._mapUrl(url))
+            .catch(err => err.errno === -2 ? { status: 404 } : err)
     }
     itemExists(url) {
         return fs.promises.access(this._mapUrl(url))


### PR DESCRIPTION
`npm run test:file` works again, so travis also succeeds now :)

I wanted to finish this because I already spent some time on getting closer to the error. So this is probably the last proactive PR from me for a while.

And as a side note: If some of the tests fail it doesn't necessarily mean that the code is broken. It's more like a hint to check it again. The test cases could also be wrong. But the test cases show which function seems to be wrong and what behavior of it seems not to work. So it should be easy to check if the code has a failure or the tests are written in the wrong way.