### PR TITLE
update links tests for https:

### DIFF
--- a/tests/SolidApi.composed.test.js
+++ b/tests/SolidApi.composed.test.js
@@ -1,4 +1,3 @@
-
 import SolidApi, { MERGE } from '../src/SolidApi'
 import apiUtils from '../src/utils/apiUtils'
 import TestFolderGenerator from './utils/TestFolderGenerator'
@@ -21,7 +20,7 @@ const container = new BaseFolder(getTestContainer(), 'SolidApi-composed', [
   turtleFile
 ])
 
-jest.setTimeout(20 * 1000)
+jest.setTimeout(30 * 1000)
 
 beforeAll(async () => {
   await contextSetup()

--- a/tests/utils/TestFolderGenerator.js
+++ b/tests/utils/TestFolderGenerator.js
@@ -341,11 +341,13 @@ const getSampleAcl = itemName => `
 @prefix n0: <http://www.w3.org/ns/auth/acl#>.
 @prefix item: <./${itemName}>.
 @prefix c: </profile/card#>.
+@prefix n1: <http://xmlns.com/foaf/0.1/>.
 
 :ControlReadWrite
     a n0:Authorization;
     n0:accessTo item:;
     n0:agent c:me;
+    n0:agentClass n1:Agent;
     n0:default item:;
     n0:mode n0:Control, n0:Read, n0:Write.
 `


### PR DESCRIPTION
@Otto-AA @jeff-zucker 
the SolidApi.links.test.js are now compliant with https:

Tests passes except one : 

The test `copyFolder without links` need to be modified but I don't know-howto :
```
● recursive › copyFolder › copies folder without links

    expect(received).toEqual(expected) // deep equality

    - Expected
    + Received

      Array [
    -   Any<String>,
    -   false,
    +   "https://bourgeoa.bourgeoa.ga/public/tests/test-folder/SolidApi-links/copy-folder/target/.meta",
    +   true,
```
 
- /target/meta is created by default by createFolder() with length 0 in the copyFolder(withoutLinks param)
- and we must check that it is not created from /source/meta which has length 12

Except the above there is in SolidApi.composed one fail HEAD for folder returns contentType `application/octet-stream` and it was expected as `text/turtle`