### PR TITLE
add withMeta=false to copyFile()

### DIFF
--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -437,6 +437,7 @@ class SolidAPI {
   async copyFile (from, to, options) {
     options = {
       ...defaultWriteOptions,
+      ...{ withMeta: false },
       ...options
     }
     if (from.endsWith('.acl') || to.endsWith('.acl')) {


### PR DESCRIPTION
@jeff-zucker This PR should closes issue #123 
Tested on solid.community, inrupt.dev and bourgeoa.ga
files do not have meta at this stage of NSS
It seems that https://podRoot/index.html as no link to meta in headers

Improvement : check that .meta and .acl do exists in headers issue #125 