### PR TITLE
Fix cjs to esm in rdf-query.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,13 +57,13 @@
     "jsdoc-to-markdown": "^5.0.3",
     "regenerator-runtime": "^0.13.3",
     "solid-auth-cli": "^1.0.10",
-    "solid-namespace": "^0.2.0",
     "solid-rest": "^1.1.2",
     "standard": "^14.3.1",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "n3": "^1.3.5"
+    "n3": "^1.3.5",
+    "solid-namespace": "^0.2.0"
   }
 }

--- a/src/utils/rdf-query.js
+++ b/src/utils/rdf-query.js
@@ -4,8 +4,10 @@
  *  by Jeff Zucker with contributions from Otto_A_A and Alain Bourgeois
  *  &copy; 2019, Jeff Zucker, may be freely distributed using an MIT license
  */
-const N3 = require('n3')
-const ns = require('solid-namespace')()
+import * as N3 from 'n3';
+import solidNS from 'solid-namespace';
+
+const ns = solidNS();
 
 const { DataFactory } = N3
 const { namedNode, literal } = DataFactory


### PR DESCRIPTION
Changed the cjs require statements to esm imports at the top of the file for consistency.

Moved solid-namespace from depDependencies to dependencies in Package.json