### PR TITLE
getItemLinks new options

### DIFF
--- a/src/SolidApi.js
+++ b/src/SolidApi.js
@@ -21,7 +21,7 @@ export const MERGE = {
   KEEP_TARGET: 'keep_target'
 }
 /**
- * @typedef {"exclude"|"include"|"includePossible"} LINKS
+ * @typedef {"exclude"|"include"|"include_possible"} LINKS
  * @private
  */
 export const LINKS = {
@@ -393,12 +393,12 @@ class SolidAPI {
    * @returns {Promise<Links>}
    */
   async getItemLinks (url, options = { links: LINKS.INCLUDE_POSSIBLE }) {
-    if (options.links === LINKS.EXCLUDE) {
-      toFetchError(new Error('Invalid option LINKS.EXCLUDE for getItemLinks'))
-    }
+    if (options.links === LINKS.EXCLUDE) return {}
 
     const links = await this.head(url).then(getLinksFromResponse)
     if (options.links === LINKS.INCLUDE) {
+      if (options.withAcl === false) delete links.acl
+      if (options.withMeta === false) delete links.meta
       await this._removeInexistingLinks(links)
     }
 

--- a/tests/SolidApi.links.test.js
+++ b/tests/SolidApi.links.test.js
@@ -66,8 +66,13 @@ describe('getItemLinks', () => {
         expect(links).toHaveProperty('acl', folder.acl.url)
         expect(links).not.toHaveProperty('meta')
     })
-    test('throws if links=EXCLUDE', () => {
-        return expect(api.getItemLinks(folder.url, { links: LINKS.EXCLUDE })).rejects.toThrow(/Invalid option/)
+    test('returns {} links for a folder with links=INCLUDE & withAcl=false', async () => {
+        const links = await api.getItemLinks(folder.url, { links: LINKS.INCLUDE, withAcl: false })
+        expect(links).toEqual({})
+    })
+    test('returns {} for a folder with links=EXCLUDE', async () => {
+        const links = await api.getItemLinks(folder.url, { links: LINKS.EXCLUDE })
+        expect(links).toEqual({})
     })
 })
 


### PR DESCRIPTION
- for links='exclude' : replace throw error by return {}, this avoid to test an exception
- for links='include' : add withAcl=false & withMeta= false to exclude existing .acl or .meta selectively